### PR TITLE
Some improvements to docs and call_thai.sh

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,9 +8,11 @@ The task is **word similarity**, which is often used for intrinsic evaluation of
 In the fork we added Spearman rho as additional evaluation measure, and added the option to tokenize 
 out-of-vocabulary words with the `deepcut` library.
 
-To evaluate your own Thai word embedding file, please the path to your model into ``examples/call_thai.sh``, and then call the script::
-
-    bash examples/call_thai.sh
+First, please follow the installation guide from the original repo which is duplicated below as well.
+Then execute following commands to evaluate your own Thai word embedding file::
+	cd examples
+	chmod +x call_thai.sh
+    bash examples/call_thai.sh <path_to_your_embedding_file>
 
 The datasets were created by KMITL University, Ladkrabang, Thailand (Dr. Ponrudee Netisopakul) together with ITMO University, St. Petersburg, Russia (Dr. Gerhard Wohlgenannt,
 Aleksei Pulich).

--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ First, please follow the installation guide from the original repo which is dupl
 Then execute following commands to evaluate your own Thai word embedding file::
 	cd examples
 	chmod +x call_thai.sh
-    bash examples/call_thai.sh <path_to_your_embedding_file>
+    	bash examples/call_thai.sh <path_to_your_embedding_file>
 
 The datasets were created by KMITL University, Ladkrabang, Thailand (Dr. Ponrudee Netisopakul) together with ITMO University, St. Petersburg, Russia (Dr. Gerhard Wohlgenannt,
 Aleksei Pulich).

--- a/examples/call_thai.sh
+++ b/examples/call_thai.sh
@@ -1,8 +1,12 @@
 # argv: embeddingfile   -   emb_format  - TOKENIZE_OOV_WORDS_WITH_DEEPCUT (default:False)  -  FILTER_NOT_FOUND (default: False)
 
-# to evaluate your own model, fill in and uncomment:
-# you only need to change this next line
-EMB=path-to-the-embedding-model
+if [ $# -eq 0 ]
+  then
+    echo "Wrong usage. Please, pass the path to the embeddings."
+    echo "./call_thai.sh <some_path>"
+    exit 1
+fi
+EMB=$1
 
 ################################################################################################################################
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 matplotlib>=1.5.0
 numpy>=1.10.0
 Cython
-pandas==0.19
+pandas
 pytest>=2.8.3
 scipy>=0.9
 scikit-learn>=0.16.1
@@ -10,3 +10,4 @@ futures
 tqdm
 docopt
 deepcut
+tensorflow


### PR DESCRIPTION
1. It could be obvious, but maybe it's worth mentioning to set right permissions for call_thai.sh with "chmod +x examples/call_thai.sh"
2. As in call_thai.sh paths to python scripts are relative, I guess it would be better to explicitly describe in readme that user have to run "cd examples" first. If I run the script like ./examples/call_thai.sh in current realization I get errors that those scripts are not found (it's searching it in the current directory which is root of the project)
3. tensorflow is used but not described in requirements.txt
4. I find the way we pass a path to an embeddings file not that convenient, so I have tuned the bash script to expect the path to embeddings with an argument like ./call_thai.sh <some_file.vec>
5. Maybe something wrong with my machine but pandas==0.19 is always failing during install on my laptop with virtualenv based on python 3.7. With latest pandas everything is ok.